### PR TITLE
テンプレートリポジトリと本リポジトリの記載差異の書き方を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,27 @@
 
 ## リポジトリの構成
 
-書籍では、章を読み進めるごとに徐々にWebアプリケーションを構築していけるようになっています。
+書籍では、章を読み進めるごとに徐々にWebアプリケーションを構築していけるようになっています。以下の2つのリポジトリを用意していますので、用途に合わせてご参照ください。
+
+- 実装し始めるための環境を格納した[テンプレートリポジトリ](#テンプレートリポジトリ)
+- 章の区切りごとのソースコードを確認するためのリポジトリ（[本リポジトリ](#本リポジトリ)）
+
+### テンプレートリポジトリ
 
 書籍を読みながら自身でコードを書き進めたい方のために、[開発に必要な設定やファイルを事前準備済みのテンプレートリポジトリ](https://github.com/rust-web-app-book/rusty-book-manager-template)を用意していますので、ぜひご利用ください。
 
 - https://github.com/rust-web-app-book/rusty-book-manager-template
 
-それに加えて本リポジトリでは、ブランチにて書籍の区切り（章・節）ごとのソースコード一式を参照できるようにしてあります。[ブランチの一覧](#ブランチの一覧)をご参照ください。
-
-書籍上ではソースコードを掲載していないフロントエンドとインフラのコードも本リポジトリに格納しています。それぞれ以下のディレクトリおよびディレクトリ内の `README.md` をご参照ください。
+テンプレートリポジトリには、書籍上ではソースコードを掲載していないフロントエンドとインフラのコードも格納しています。テンプレートリポジトリ内の以下のディレクトリおよびディレクトリ内の `README.md` をご参照ください。
 
 - フロントエンド：`frontend` ディレクトリ
 - インフラ： `infra` ディレクトリ
 
-### ブランチの一覧
+### 本リポジトリ
+
+本リポジトリでは、書籍の区切り（章・節）ごとのソースコード一式をブランチにて参照できるようにしてあります。[ブランチの一覧](#ブランチの一覧)をご参照ください。
+
+#### ブランチの一覧
 
 - [chapter2](https://github.com/rust-web-app-book/rusty-book-manager/tree/chapter2)：2章の終わり時点
 - [chapter3](https://github.com/rust-web-app-book/rusty-book-manager/tree/chapter3)：3章の終わり時点
@@ -32,4 +39,3 @@
   - [chapter5-8](https://github.com/rust-web-app-book/rusty-book-manager/tree/chapter5-8)：5.8節の終わり時点
 - [chapter6](https://github.com/rust-web-app-book/rusty-book-manager/tree/chapter6)：6章の終わり時点
 - [chapter7](https://github.com/rust-web-app-book/rusty-book-manager/tree/chapter7)：7章の終わり時点
-


### PR DESCRIPTION
`infra` と `frontend` を格納するリポジトリの記載が誤っていたので修正した。
具体的には、本リポジトリに格納する記載になっていたのでテンプレートリポジトリの方にあるよという記載に修正し、あとは見出しを追加して見やすくした。

見た目確認用リンク
https://github.com/rust-web-app-book/rusty-book-manager/blob/fix/readme/README.md